### PR TITLE
Eden and Frodo compatibility added

### DIFF
--- a/XBMCnfoTV.bundle/Contents/Code/__init__.py
+++ b/XBMCnfoTV.bundle/Contents/Code/__init__.py
@@ -111,6 +111,10 @@ class xbmcnfo(Agent.TV_Shows):
 			posterFilename = path + "/../season-all-poster.jpg"
 		if os.path.exists(path + "/season-all-poster.jpg"):
 			posterFilename = path + "/season-all-poster.jpg"
+		if os.path.exists(path + "/../folder.jpg"):
+			posterFilename = path + "/../folder.jpg"
+		if os.path.exists(path + "/folder.jpg"):
+			posterFilename = path + "/folder.jpg"
 		if os.path.exists(path + "/../poster.jpg"):
 			posterFilename = path + "/../poster.jpg"
 		if os.path.exists(path + "/poster.jpg"):
@@ -121,6 +125,10 @@ class xbmcnfo(Agent.TV_Shows):
 			Log('Found poster image at ' + posterFilename)
 
 		bannerFilename = ""
+		if os.path.exists(path + "/../folder-banner.jpg"):
+			bannerFilename = path + "/../folder-banner.jpg"
+		if os.path.exists(path + "/folder-banner.jpg"):
+			bannerFilename = path + "/folder-banner.jpg"
 		if os.path.exists(path + "/../banner.jpg"):
 			bannerFilename = path + "/../banner.jpg"
 		if os.path.exists(path + "/banner.jpg"):


### PR DESCRIPTION
XBMC Frodo now provides thumbs and posters with .jpg extension instead of Eden's .tbn extension. the code now checks first for Eden's and then for Frodo's extensions. additionally, it looks for posters and banners without the "folder" prefix to increase compatibility.
