### PR TITLE
Fixed index out of range error

### DIFF
--- a/XBMCnfoTV.bundle/Contents/Code/__init__.py
+++ b/XBMCnfoTV.bundle/Contents/Code/__init__.py
@@ -83,7 +83,7 @@ class xbmcnfo(Agent.TV_Shows):
 	def update(self, metadata, media, lang):
 		id = media.id
 		Log('Update called for TV Show with id = ' + id)
-		path1 = media.items[0].parts[0].file
+		path1 = media.seasons[1].episodes[1].items[0].parts[0].file
 		path = os.path.dirname(path1)
 		parse_date = lambda s: Datetime.ParseDate(s).date()
 		


### PR DESCRIPTION
TVShow scraping should now work again. It does for me at least. Please check and pull if it works for you, too.
