### PR TITLE
Fix: Duration, Multiline Items | Clean Up: Comments, Log

### DIFF
--- a/XBMCnfoTV.bundle/Contents/Code/__init__.py
+++ b/XBMCnfoTV.bundle/Contents/Code/__init__.py
@@ -52,15 +52,15 @@ class xbmcnfo(Agent.TV_Shows):
 			nfoName = path1 + "/tvshow.nfo"
 			Log('Looking for TV Show NFO file at ' + nfoName)
 
-		tvshowid = media.id
+		id = media.id
 		year = 0
-		tvshowname = None
+		title = None
 
 		if not os.path.exists(nfoName):
 			Log("Couldn't find a tvshow.nfo file; will use the folder name as the TV show title:")
 			path = os.path.dirname(path1)
-			tvshowname = os.path.basename(path)
-			Log("Using tvshow.title = " + tvshowname)
+			title = os.path.basename(path)
+			Log("Using tvshow.title = " + title)
 		else:
 			nfoFile = nfoName
 			Log("Found nfo file at " + nfoFile)
@@ -78,28 +78,30 @@ class xbmcnfo(Agent.TV_Shows):
 					Log('ERROR: Cant parse XML in ' + nfoFile + '. Aborting!')
 					return
 				Log(nfoXML.xpath("title"))
-				#tv show name
-				try: tvshowname=nfoXML.xpath("title")[0].text
+				
+				# Title
+				try: title = nfoXML.xpath("title")[0].text
 				except:
 					Log("ERROR: No <title> tag in " + nfoFile + ". Aborting!")
 					return
-				#tv show name
-				try: year=parse_date(nfoXML.xpath("premiered")[0].text).year
+				# Year
+				try: year = parse_date(nfoXML.xpath("premiered")[0].text).year
 				except: pass
-				#tv tv show id
-				try: tvshowid=nfoXML.xpath("id")[0].text
+				# ID
+				try: id = nfoXML.xpath("id")[0].text
 				except:
 					# if tv show id doesn't exist, create
-					# one based on hash of tvshowname
+					# one based on hash of title
 					ord3 = lambda x : '%.3d' % ord(x) 
-					tvshowid=int(''.join(map(ord3, tvshowname)))
-					tvshowid=str(abs(hash(int(tvshowid))))
-				Log('Show name: ' + tvshowname)
-				Log('Show ID: ' + tvshowid)
+					id = int(''.join(map(ord3, title)))
+					id = str(abs(hash(int(id))))
+					
+				Log('ID: ' + id)
+				Log('Title: ' + title)
 				Log('Year: ' + str(year))
 
-		results.Append(MetadataSearchResult(id=tvshowid, name=tvshowname, year=year, lang=lang, score=100))
-		Log('scraped results: ' + tvshowname + ' | year = ' + str(year) + ' | id = ' + tvshowid)
+		results.Append(MetadataSearchResult(id=id, name=title, year=year, lang=lang, score=100))
+		Log('scraped results: ' + title + ' | year = ' + str(year) + ' | id = ' + id)
 
 ##### update Function #####
 	def update(self, metadata, media, lang):
@@ -201,71 +203,66 @@ class xbmcnfo(Agent.TV_Shows):
 				except:
 					Log('ERROR: Cant parse XML in ' + nfoFile + '. Aborting!')
 					return
-				#tv show name
-				try: metadata.title=nfoXML.xpath("title")[0].text
+				
+				# Title
+				try: metadata.title = nfoXML.xpath("title")[0].text
 				except:
 					Log("ERROR: No <title> tag in " + nfoFile + ". Aborting!")
 					return
-				#tv show original name
-				try: metadata.original_title = nfoXML.xpath('./originaltitle')[0].text
+				# Original Title
+				try: metadata.original_title = nfoXML.xpath('originaltitle')[0].text
 				except: pass
-				#tv show summary
-				try: metadata.summary=nfoXML.xpath("plot")[0].text
+				# Rating
+				try: metadata.rating = float(nfoXML.xpath("rating")[0].text.replace(',', '.'))
 				except: pass
-				#tv show tagline
+				# Content Rating
+				try:
+					mpaa = nfoXML.xpath('./mpaa')[0].text
+					match = re.match(r'(?:Rated\s)?(?P<mpaa>[A-z0-9-+/.]+(?:\s[0-9]+[A-z]?)?)?', mpaa)
+					if match.group('mpaa'):
+						content_rating = match.group('mpaa')
+					else:
+						content_rating = 'NR'
+					metadata.content_rating = content_rating
+				except: pass
+				# Network
+				try: metadata.studio = nfoXML.xpath("studio")[0].text
+				except: pass
+				# Premiere
+				try: metadata.originally_available_at = parse_date(nfoXML.xpath("premiered")[0].text)
+				except: pass
+				# Tagline
 				try: metadata.tagline = nfoXML.findall("tagline")[0].text
 				except: pass
-				#tv show year and first Aired
-				try: metadata.originally_available_at=parse_date(nfoXML.xpath("premiered")[0].text) #metadata.originally_available_at=nfoXML.xpath("aired")[0].text
+				# Summary (Plot)
+				try: metadata.summary = nfoXML.xpath("plot")[0].text
 				except: pass
-				#tv show rating
-				try: metadata.rating=float(nfoXML.xpath("rating")[0].text.replace(',','.'))
-				except: pass
-				#tv show content rating
+				# Genres
 				try:
-					match = re.match(r'(?:Rated\s)?(?P<mpaa>[A-z0-9-+/.]+(?:\s[0-9]+[A-z]?)?)?', nfoXML.xpath('./mpaa')[0].text)
-					if match.group('mpaa'):
-						metadata.content_rating = match.group('mpaa')
-					else:
-						metadata.content_rating = 'NR'
+					genres = nfoXML.xpath('genre')
+					metadata.genres.clear()
+					[metadata.genres.add(g.strip()) for genreXML in genres for g in genreXML.text.split("/")]
+					metadata.genres.discard('')
 				except: pass
-				#tv show network
-				try: metadata.studio=nfoXML.xpath("studio")[0].text
-				except: pass
-				#tv show duration
+				# Collections (Set)
 				try:
-					sruntime=nfoXML.xpath("runtime")[0].text
+					sets = nfoXML.xpath('set')
+					metadata.collections.clear()
+					[metadata.collections.add(s.strip()) for setXML in sets for s in setXML.text.split("/")]
+					metadata.collections.discard('')
+				except: pass
+				# Duration
+				try:
+					sruntime = nfoXML.xpath("runtime")[0].text
 					duration = int(re.compile('^([0-9]+)').findall(sruntime)[0])
 					duration_ms = xbmcnfo.time_convert (self, duration)
 					metadata.duration = duration_ms
 					Log("Set Series Episode Duration from " + str(duration) + " in tvshow.nfo file to " + str(duration_ms) + " in Plex.")
 				except:
-					metadata.duration = 0
 					Log("No Series Episode Duration in tvschow.nfo file.")
-					pass
-				#set/collections
-				try:
-					set_ = nfoXML.xpath('./set')[0].text
-					metadata.collections.clear()
-					metadata.collections.add(set_)
-				except: pass
-				#genre, cant see mulltiple only sees string not seperate genres
-				try:
-					genres = nfoXML.xpath('./genre')
-					metadata.genres.clear()
-					for genreXML in genres:
-						gs = genreXML.text.split("/")
-						if gs != "":
-							for g in gs:
-								metadata.genres.add(g.strip())
-				except: pass
-				Log('Title: ' + metadata.title)
-				if metadata.originally_available_at:
-					Log('Aired: ' + str(metadata.originally_available_at.year) + '-' + str(metadata.originally_available_at.month) + '-' + str(metadata.originally_available_at.day))
-
-				#actors
+				# Actors
 				metadata.roles.clear()
-				for actor in nfoXML.findall('./actor'):
+				for actor in nfoXML.xpath('actor'):
 					role = metadata.roles.new()
 					try: role.role = actor.xpath("role")[0].text
 					except: pass
@@ -273,29 +270,68 @@ class xbmcnfo(Agent.TV_Shows):
 					except: pass
 					try: role.photo = actor.xpath("thumb")[0].text
 					except: pass
-					#if role.photo and role.photo != 'None' and role.photo != '':
-						#data = HTTP.Request(actor.xpath("thumb")[0].text)
-						#Log('Added Thumbnail for: ' + role.actor)
-
+					# if role.photo and role.photo != 'None' and role.photo != '':
+						# data = HTTP.Request(actor.xpath("thumb")[0].text)
+						# Log('Added Thumbnail for: ' + role.actor)
+				
+				# Log('Title: ' + metadata.title)
+				# if metadata.originally_available_at:
+					# Log('Aired: ' + str(metadata.originally_available_at.year) + '-' + str(metadata.originally_available_at.month) + '-' + str(metadata.originally_available_at.day))
+					
+				Log("---------------------")
+				Log("Series nfo Information")
+				Log("---------------------")
+				try: Log("ID: " + str(metadata.guid))
+				except: Log("ID: -")
+				try: Log("Title: " + str(metadata.title))
+				except: Log("Title: -")
+				try: Log("Original: " + str(metadata.original_title))
+				except: Log("Original: -")
+				try: Log("Rating: " + str(metadata.rating))
+				except: Log("Rating: -")
+				try: Log("Content: " + str(metadata.content_rating))
+				except: Log("Content: -")
+				try: Log("Network: " + str(metadata.studio))
+				except: Log("Network: -")
+				try: Log("Premiere: " + str(metadata.originally_available_at))
+				except: Log("Premiere: -")
+				try: Log("Tagline: " + str(metadata.tagline))
+				except: Log("Tagline: -")
+				try: Log("Summary: " + str(metadata.summary))
+				except: Log("Summary: -")
+				Log("Genres:")
+				try: [Log("\t" + genre) for genre in metadata.genres]
+				except: Log("\t-")
+				Log("Collections:")
+				try: [Log("\t" + collection) for collection in metadata.collections]
+				except: Log("\t-")
+				try: Log("Duration: " + str(metadata.duration // 60000) + ' min')
+				except: Log("Duration: -")
+				Log("Actors:")
+				try: [Log("\t" + actor.actor + " > " + actor.role) for actor in metadata.roles]
+				except: [Log("\t" + actor.actor) for actor in metadata.roles]
+				except: Log("\t-")
+				Log("---------------------")
+				
 		# Grabs the season data
 		@parallelize
 		def UpdateEpisodes():
 			Log("UpdateEpisodes called")
-			pageUrl="http://localhost:32400/library/metadata/" + media.id + "/children"
+			pageUrl = "http://localhost:32400/library/metadata/" + media.id + "/children"
 			seasonList = XML.ElementFromURL(pageUrl).xpath('//MediaContainer/Directory')
 
-			seasons=[]
+			seasons = []
 			for seasons in seasonList:
-				try: seasonID=seasons.get('key')
+				try: seasonID = seasons.get('key')
 				except: pass
-				try: season_num=seasons.get('index')
+				try: season_num = seasons.get('index')
 				except: pass
 				
 				Log("seasonID : " + path)
 				if seasonID.count('allLeaves') == 0:
 					Log("Finding episodes")
 
-					pageUrl="http://localhost:32400" + seasonID
+					pageUrl = "http://localhost:32400" + seasonID
 
 					episodes = XML.ElementFromURL(pageUrl).xpath('//MediaContainer/Video')
 					Log("Found " + str(len(episodes)) + " episodes.")
@@ -344,10 +380,10 @@ class xbmcnfo(Agent.TV_Shows):
 						def UpdateEpisode(episode=episode, season_num=season_num, ep_num=ep_num, ep_key=ep_key, path=path1):
 							Log("UpdateEpisode called for episode S" + str(season_num.zfill(2)) + "E" + str(ep_num.zfill(2)))
 							if(ep_num.count('allLeaves') == 0):
-								pageUrl="http://localhost:32400" + ep_key + "/tree"
+								pageUrl = "http://localhost:32400" + ep_key + "/tree"
 								path1 = XML.ElementFromURL(pageUrl).xpath('//MediaPart')[0].get('file')
 								Log('UPDATE: ' + path1)
-								filepath=path1.split
+								filepath = path1.split
 								path = os.path.dirname(path1)
 								fileExtension = path1.split(".")[-1].lower()
 
@@ -370,13 +406,25 @@ class xbmcnfo(Agent.TV_Shows):
 											Log('ERROR: Cant parse XML in file: ' + nfoFile)
 											return
 
-										#title
-										try: episode.title = nfoXML.xpath('./title')[0].text
+										# Ep. Title
+										try: episode.title = nfoXML.xpath('title')[0].text
+										except:
+											Log("ERROR: No <title> tag in " + nfoFile + ". Aborting!")
+											return
+										# Ep. Content Rating
+										try:
+											mpaa = nfoXML.xpath('./mpaa')[0].text
+											match = re.match(r'(?:Rated\s)?(?P<mpaa>[A-z0-9-+/.]+(?:\s[0-9]+[A-z]?)?)?', mpaa)
+											if match.group('mpaa'):
+												content_rating = match.group('mpaa')
+											else:
+												content_rating = 'NR'
+											episode.content_rating = content_rating
 										except: pass
-										#summary
-										try: episode.summary = nfoXML.xpath('./plot')[0].text
+										# Ep. Rating
+										try: episode.rating = float(nfoXML.xpath('rating')[0].text.replace(',', '.'))
 										except: pass
-										#year
+										# Ep. Premiere
 										try:
 											try:
 												air_date = time.strptime(nfoXML.xpath("aired")[0].text, "%d %B %Y")
@@ -385,36 +433,26 @@ class xbmcnfo(Agent.TV_Shows):
 											if air_date:
 												episode.originally_available_at = datetime.datetime.fromtimestamp(time.mktime(air_date)).date()
 										except: pass
-										#rating
-										try: episode.rating = float(nfoXML.xpath('./rating')[0].text.replace(',','.'))
+										# Ep. Summary
+										try: episode.summary = nfoXML.xpath('plot')[0].text
 										except: pass
-										#content rating
-										try: episode.content_rating = nfoXML.xpath('./mpaa')[0].text
-										except: pass
-										#director
+										# Ep. Writers (Credits)
 										try: 
-											directors = nfoXML.xpath('./director')
-											episode.directors.clear()
-											for directorXML in directors:
-												ds = directorXML.text.split("/")
-												if ds != "":
-													for d in ds:
-														episode.directors.add(d)
-										except: pass
-										#writers/credits
-										try: 
-											credits = nfoXML.xpath('./credits')
+											credits = nfoXML.xpath('credits')
 											episode.writers.clear()
-											for creditXML in credits:
-												writer = creditXML.text
-												episode.writers.add(writer)
+											[episode.writers.add(c.strip()) for creditXML in credits for c in creditXML.text.split("/")]
+											episode.writers.discard('')
 										except: pass
-										#studio
-										try: episode.studio = nfoXML.findall("studio")[0].text
+										# Ep. Directors
+										try: 
+											directors = nfoXML.xpath('director')
+											episode.directors.clear()
+											[episode.directors.add(d.strip()) for directorXML in directors for d in directorXML.text.split("/")]
+											episode.directors.discard('')
 										except: pass
-										#runtime
+										# Ep. Duration
 										try:
-											eruntime = nfoXML.findall("runtime")[0].text
+											eruntime = nfoXML.xpath("runtime")[0].text
 											eduration = int(re.compile('^([0-9]+)').findall(eruntime)[0])
 											eduration_ms = xbmcnfo.time_convert (self, eduration)
 											episode.duration = eduration_ms
@@ -422,9 +460,8 @@ class xbmcnfo(Agent.TV_Shows):
 												eduration_min = int(round (float(eduration_ms) / 1000 / 60))
 												Dict[duration_key][eduration_min] = Dict[duration_key][eduration_min] + 1
 										except:
-											eduration = eduration_min = eduration_ms = 0
+											episode.duration = metadata.duration if metadata.duration else None
 											Log ("No Episode Duration in episodes .nfo file.")
-											pass
 										
 										# thumbPathFilenameDLNA = nfoFile.replace('.nfo', '.jpg')
 										# thumbFilenameDLNA = thumbPathFilenameDLNA.replace(path+'\\', '')
@@ -456,24 +493,49 @@ class xbmcnfo(Agent.TV_Shows):
 												Log("Found episode thumb " + thumbURL)
 												try: episode.thumbs[thumbURL] = Proxy.Media(HTTP.Request(thumbURL))
 												except: pass
-										try:
-												ep_summary = episode.summary.replace("\n", " ")
-										except:
-												ep_summary = episode.summary
-										indent = '{:>61}'#.format('')
-										logtext = ("" +
-										"+++++++++++++++++++++++++++++++++\n" + indent +
-										"TV Episode S" + season_num.zfill(2) + "E" + ep_num.zfill(2) + " nfo Information\n" + indent +
-										"---------------------------------\n" + indent +
-										"Title: " + str(episode.title) + "\n" + indent +
-										"Summary: " + str(ep_summary) + "\n" + indent +
-										"Year: " + str(episode.originally_available_at) + "\n" + indent +
-										"IMDB rating: " + str(episode.rating) + "\n" + indent +
-										"Episode .nfo: " + str(eduration) + "\n" + indent +
-										"Episode ms: " + str(eduration_ms) + "\n" + indent +
-										"Episode min: " + str(eduration_min) + "\n" + indent +
-										"+++++++++++++++++++++++++++++++++")
-										Log(logtext)
+												
+										# try:
+												# ep_summary = episode.summary.replace("\n", " ")
+										# except:
+												# ep_summary = episode.summary
+												
+										# indent = '{:>61}'#.format('')
+										# logtext = ("" +
+										# "+++++++++++++++++++++++++++++++++\n" + indent +
+										# "TV Episode S" + season_num.zfill(2) + "E" + ep_num.zfill(2) + " nfo Information\n" + indent +
+										# "---------------------------------\n" + indent +
+										# "Title: " + str(episode.title) + "\n" + indent +
+										# "Summary: " + str(ep_summary) + "\n" + indent +
+										# "Year: " + str(episode.originally_available_at) + "\n" + indent +
+										# "IMDB rating: " + str(episode.rating) + "\n" + indent +
+										# "Episode .nfo: " + str(eduration) + "\n" + indent +
+										# "Episode ms: " + str(eduration_ms) + "\n" + indent +
+										# "Episode min: " + str(eduration_min) + "\n" + indent +
+										# "+++++++++++++++++++++++++++++++++")
+										# Log(logtext)
+										
+										Log("---------------------")
+										Log("Episode (S"+season_num.zfill(2)+"E"+ep_num.zfill(2)+") nfo Information")
+										Log("---------------------")
+										try: Log("Title: " + str(episode.title))
+										except: Log("Title: -")
+										try: Log("Content: " + str(episode.content_rating))
+										except: Log("Content: -")
+										try: Log("Rating: " + str(episode.rating))
+										except: Log("Rating: -")
+										try: Log("Premiere: " + str(episode.originally_available_at))
+										except: Log("Premiere: -")
+										try: Log("Summary: " + str(episode.summary))
+										except: Log("Summary: -")
+										Log("Writers:")
+										try: [Log("\t" + writer) for writer in episode.writers]
+										except: Log("\t-")
+										Log("Directors:")
+										try: [Log("\t" + director) for director in episode.directors]
+										except: Log("\t-")
+										try: Log("Duration: " + str(episode.duration // 60000) + ' min')
+										except: Log("Duration: -")
+										Log("---------------------")
 									else:
 										Log("ERROR: <episodedetails> tag not found in episode NFO file " + nfoFile)
 


### PR DESCRIPTION
Duration:
Episode duration equals series duration, if unavailable

Multiline Items:
Genres, Collections, Writers, Directors can read both multiple lines and one line separated by '/'.

Comments:
Made More readable/sensible.

Log:
Added/changed to log more data for easier debugging.
