### PR TITLE
fix duration NaN issue when nfo file contains runtime of 0

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -624,7 +624,7 @@ class xbmcnfotv(Agent.TV_Shows):
 		# Final Steps
 		duration_min = 0
 		duration_string = ""
-		if metadata.duration == None:
+		if not metadata.duration:
 			try:
 				duration_min = Dict[duration_key].index(max(Dict[duration_key]))
 				for d in Dict[duration_key]:


### PR DESCRIPTION
Sometimes XBMC outputs:

```
<runtime>0</runtime>
```

This seems to be triggering the `NaN` issue as well. By running this block whenever `metadata.duration` is `0` or `None` it fixes the issue for me.
