### PR TITLE
Remove Sick Beard's xbmcmultiepisodenfo element

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -612,6 +612,9 @@ class xbmcnfotv(Agent.TV_Shows):
 									# strip media browsers <multiepisodenfo> tags
 									nfoText = nfoText.replace ('<multiepisodenfo>','')
 									nfoText = nfoText.replace ('</multiepisodenfo>','')
+									# strip Sick Beard's <xbmcmultiepisodenfo> tags
+									nfoText = nfoText.replace ('<xbmcmultiepisode>','')
+									nfoText = nfoText.replace ('</xbmcmultiepisode>','')									
 									# work around failing XML parses for things with &'s in them. This may need to go farther than just &'s....
 									nfoText = re.sub(r'&(?![A-Za-z]+[0-9]*;|#[0-9]+;|#x[0-9a-fA-F]+;)', r'&amp;', nfoText)
 									# remove empty xml tags from nfo


### PR DESCRIPTION
Sick Beard places an <xbmcmultiepisodenfo> root element around the <episodedetails> if there are multiple episodes in the nfo - which breaks the scanning.