### PR TITLE
Make episode thumbnail always downloaded

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -505,12 +505,11 @@ class xbmcnfotv(Agent.TV_Shows):
 					try: role.role = actor.xpath("role")[0].text
 					except:
 						role.role = "unknown"
-					if not Prefs['localmediaagent']:
-						try: role.photo = actor.xpath("thumb")[0].text
-						except: pass
-						# if role.photo and role.photo != 'None' and role.photo != '':
-							# data = HTTP.Request(actor.xpath("thumb")[0].text)
-							# Log('Added Thumbnail for: ' + role.name)
+					try: role.photo = actor.xpath("thumb")[0].text
+					except: pass
+					# if role.photo and role.photo != 'None' and role.photo != '':
+					# data = HTTP.Request(actor.xpath("thumb")[0].text)
+					# Log('Added Thumbnail for: ' + role.name)
 
 
 				Log("---------------------")


### PR DESCRIPTION
Recently I changed TVDB agent to XBMCnfoTVImporter for my anime library.
When I turn on the option to use local media agent, actor photos are not imported.
The local media agent doesn't do anything for actor photo, so this part should fixed.