### PR TITLE
Fix thetvdb ratings

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -430,8 +430,15 @@ class xbmcnfotv(Agent.TV_Shows):
 					self.DLog("Series Rating found: " + str(nforating))
 				except:
 					self.DLog("Can't read rating from tvshow.nfo.")
-					nforating = 0.0
-					pass
+					self.DLog("Trying to get a rating of additional ratings from tvshow.nfo.")
+					try:
+						nforating = round(float(nfoXML.xpath("ratings")[0][0][0].text.replace(',', '.')),1)
+						metadata.rating = nforating
+						self.DLog("Found first rating in additional ratings: " + str(nforating))
+					except:
+						self.DLog("Can't read ratings from tvshow.nfo.")
+						nforating = 0.0
+						pass
 				if Prefs['altratings']:
 					self.DLog("Searching for additional Ratings...")
 					allowedratings = Prefs['ratings']
@@ -462,7 +469,6 @@ class xbmcnfotv(Agent.TV_Shows):
 								if ratingprovider in allowedratings or allowedratings == "":
 									self.DLog("adding rating: " + ratingprovider + ": " + ratingvalue)
 									addratingsstring = addratingsstring + " | " + ratingprovider + ": " + ratingvalue
-								nforating = round(float(ratingvalue),1)
 							if addratingsstring != "":
 								self.DLog("Putting additional ratings at the " + Prefs['ratingspos'] + " of the summary!")
 								if Prefs['ratingspos'] == "front":

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -449,15 +449,20 @@ class xbmcnfotv(Agent.TV_Shows):
 								try:
 									ratingprovider = str(addrating.attrib['moviedb'])
 								except:
-									pass
-									self.DLog("Skipping additional rating without moviedb attribute!")
-									continue
+									try:
+										ratingprovider = str(addrating.attrib['name'])
+										addrating = addrating[0]
+									except:
+										pass
+										self.DLog("Skipping additional rating without provider attribute!")
+										continue
 								ratingvalue = str(addrating.text.replace (',','.'))
 								if ratingprovider.lower() in PERCENT_RATINGS:
 									ratingvalue = ratingvalue + "%"
 								if ratingprovider in allowedratings or allowedratings == "":
 									self.DLog("adding rating: " + ratingprovider + ": " + ratingvalue)
 									addratingsstring = addratingsstring + " | " + ratingprovider + ": " + ratingvalue
+								nforating = round(float(ratingvalue),1)
 							if addratingsstring != "":
 								self.DLog("Putting additional ratings at the " + Prefs['ratingspos'] + " of the summary!")
 								if Prefs['ratingspos'] == "front":


### PR DESCRIPTION
Hi,

This change is to correct the **non-loading** of the "rating" coming from "thetvdb.com" as this saves its rating within the tag "ratings".

Example file (.nfo) with metadata form thetvdb.com
```
<year>2009</year>
  <ratings>
    <rating default="true" max="10" name="tvdb">
      <value>8.9</value>
      <votes>123</votes>
    </rating>
  </ratings>
<userrating>0.0</userrating>...
```
The file .nfo was generate for Kodi v18.4.

I hope it is useful.
regarts 

PS: I don't know if there is another type of structure for the "ratings" tag because I saw in the "add additional ratings to the summary" section that looks for the "rating" using the "moviedb" attribute.