### PR TITLE
feat: Added a new function for loading multiple assets

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -697,9 +697,10 @@ class xbmcnfotv(Agent.TV_Shows):
 
 					metadata.seasons[season_num].index = int(season_num)
 
-					Log('Looking for season media for %s season %s.', metadata.title, season_num)
-					try: self.findMultimedia(metadata.seasons[season_num], [path, seasonPath], 'season')
-					except Exception, e: Log("Error finding season media for season %s: %s" % (season_num, str(e)))
+					if not Prefs['localmediaagent']:
+						Log('Looking for season media for %s season %s.', metadata.title, season_num)
+						try: self.findMultimedia(metadata.seasons[season_num], [path, seasonPath], 'season')
+						except Exception, e: Log("Error finding season media for season %s: %s" % (season_num, str(e)))
 
 					episodeXML = []
 					epnumber = 0
@@ -989,12 +990,11 @@ class xbmcnfotv(Agent.TV_Shows):
 										if not Prefs['localmediaagent']:
 											multEpisode = (nfoepc > 1) and (not Prefs['multEpisodePlexPatch'] or not multEpTestPlexPatch)
 
-											episodeMetadata = metadata.seasons[season_num].episodes[ep_num]
 											episodeMedia = media.seasons[season_num].episodes[ep_num].items[0]
 											path = os.path.dirname(episodeMedia.parts[0].file)
 
 											Log('Looking for episode media for %s season %s.', metadata.title, season_num)
-											try: self.findMultimedia(episodeMetadata, [path], 'episode', episodeMedia.parts, multEpisode)
+											try: self.findMultimedia(episode, [path], 'episode', episodeMedia.parts, multEpisode)
 											except Exception, e: Log('Error finding media for episode: %s' % str(e))
 
 										Log("---------------------")

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -92,6 +92,74 @@ class xbmcnfotv(Agent.TV_Shows):
 			return text # leave as is
 		return re.sub("&#?\w+;", fixup, text)
 
+	##
+	# Search and add to plex one or more posters, banners, arts, thumbnails or themes by show, season or episode.
+	# author: https://github.com/joserick | J. Erick Carreon
+	# email: support@joserick.com
+	# date: Sep 12, 2019
+	# @param metadata Objet Plex/MetadataModel
+	# @param paths Paths where searches should be done.
+	# @param type Type media (show|season|episode)
+	# @param parts Parts of multi-episode.
+	# @return void
+
+	def findMultimedia(self, metadata, paths, type, parts=[], multEpisode=False):
+		pathFiles = {}
+		audioExts = ['mp3', 'm4a']
+		imageExts = ['jpg', 'png', 'jpeg', 'tbn']
+		rootFile = os.path.splitext(os.path.basename(parts[0].file.encode("utf-8")))[0] if parts else None
+
+		for path in paths:
+			path = path.encode("utf-8")
+			for filePath in sorted(os.listdir(path)):
+				if filePath.endswith(tuple(imageExts + audioExts)):
+					filePath = filePath.encode("utf-8")
+					fullPath = os.path.join(path, filePath)
+					if os.path.isfile(fullPath):
+						pathFiles[filePath.lower()] = fullPath
+
+		# Structure for Frodo, Eden and DLNA
+		searchTuples = []
+		if type == 'show':
+			searchTuples.append(['(show|poster|folder)-?[0-9]?[0-9]?', metadata.posters, imageExts])
+			searchTuples.append(['banner-?[0-9]?[0-9]?', metadata.banners, imageExts])
+			searchTuples.append(['(fanart|art|background|backdrop)-?[0-9]?[0-9]?', metadata.art, imageExts])
+			searchTuples.append(['theme-?[0-9]?[0-9]?', metadata.themes, audioExts])
+		elif type == 'season':
+			searchTuples.append(['season-?0?%s(-poster)?-?[0-9]?[0-9]?' % metadata.index, metadata.posters, imageExts])
+			searchTuples.append(['season-?0?%s-banner-?[0-9]?[0-9]?' % metadata.index, metadata.banners, imageExts])
+			searchTuples.append(['season-?0?%s-(fanart|art|background|backdrop)-?[0-9]?[0-9]?' % metadata.index, metadata.art, imageExts])
+			if int(metadata.index) == 0:
+				searchTuples.append(['season-specials-poster-?[0-9]?[0-9]?', metadata.posters, imageExts])
+				searchTuples.append(['season-specials-banner-?[0-9]?[0-9]?', metadata.banners, imageExts])
+				searchTuples.append(['season-specials-(fanart|art|background|backdrop)-?[0-9]?[0-9]?', metadata.art, imageExts])
+		elif type == 'episode':
+			searchTuples.append([re.escape(rootFile) + '(-|-thumb)?-?[0-9]?[0-9]?', metadata.thumbs, imageExts])
+
+		for (structure, mediaList, exts) in searchTuples:
+			validKeys = []
+			sortIndex = 1
+			filePathKeys = sorted(pathFiles.keys(), key = lambda x: os.path.splitext(x)[0])
+			for filePath in filePathKeys:
+				for ext in exts:
+					if re.match('%s.%s' % (structure, ext), filePath, re.IGNORECASE):
+						if multEpisode and ("-E" in filePath): continue
+
+						data = Core.storage.load(pathFiles[filePath])
+						mediaHash = filePath + hashlib.md5(data).hexdigest()
+
+						validKeys.append(mediaHash)
+						if mediaHash not in mediaList:
+							mediaList[mediaHash] = Proxy.Media(data, sort_order = sortIndex)
+							Log('Found season poster image at ' + filePath)
+						else:
+							Log('Skipping file %s file because it already exists.', filePath)
+						sortIndex += 1
+
+			Log('Found %d valid things for structure %s (ext: %s)', len(validKeys), structure, str(exts))
+			validKeys = [value for value in mediaList.keys() if value in validKeys]
+			mediaList.validate_keys(validKeys)
+
 ##### search function #####
 	def search(self, results, media, lang):
 		self.DLog("++++++++++++++++++++++++")
@@ -251,66 +319,9 @@ class xbmcnfotv(Agent.TV_Shows):
 			path = os.path.dirname(path1)
 
 		if not Prefs['localmediaagent']:
-			posterNames = []
-			posterNames.append (os.path.join(path, "poster.jpg"))
-			posterNames.append (os.path.join(path, "folder.jpg"))
-			posterNames.append (os.path.join(path, "show.jpg"))
-			posterNames.append (os.path.join(path, "season-all-poster.jpg"))
-
-			# check possible poster file locations
-			posterFilename = self.checkFilePaths (posterNames, 'poster')
-
-			if posterFilename:
-				posterData = Core.storage.load(posterFilename)
-				posterHash = hashlib.md5(posterData).hexdigest()
-				metadata.posters[posterHash] = Proxy.Media(posterData)
-				metadata.posters.validate_keys([posterHash])
-				Log('Found poster image at ' + posterFilename)
-
-			bannerNames = []
-			bannerNames.append (os.path.join(path, "banner.jpg"))
-			bannerNames.append (os.path.join(path, "folder-banner.jpg"))
-
-			# check possible banner file locations
-			bannerFilename = self.checkFilePaths (bannerNames, 'banner')
-
-			if bannerFilename:
-				bannerData = Core.storage.load(bannerFilename)
-				bannerHash = hashlib.md5(bannerData).hexdigest()
-				metadata.banners[bannerHash] = Proxy.Media(bannerData)
-				metadata.banners.validate_keys([bannerHash])
-				Log('Found banner image at ' + bannerFilename)
-
-			fanartNames = []
-
-			fanartNames.append (os.path.join(path, "fanart.jpg"))
-			fanartNames.append (os.path.join(path, "art.jpg"))
-			fanartNames.append (os.path.join(path, "backdrop.jpg"))
-			fanartNames.append (os.path.join(path, "background.jpg"))
-
-			# check possible fanart file locations
-			fanartFilename = self.checkFilePaths (fanartNames, 'fanart')
-
-			if fanartFilename:
-				fanartData = Core.storage.load(fanartFilename)
-				fanartHash = hashlib.md5(fanartData).hexdigest()
-				metadata.art[fanartHash] = Proxy.Media(fanartData)
-				metadata.art.validate_keys([fanartHash])
-				Log('Found fanart image at ' + fanartFilename)
-
-			themeNames = []
-
-			themeNames.append (os.path.join(path, "theme.mp3"))
-
-			# check possible theme file locations
-			themeFilename = self.checkFilePaths (themeNames, 'theme')
-
-			if themeFilename:
-				themeData = Core.storage.load(themeFilename)
-				themeHash = hashlib.md5(themeData).hexdigest()
-				metadata.themes[themeHash] = Proxy.Media(themeData)
-				metadata.themes.validate_keys([themeHash])
-				Log('Found theme music ' + themeFilename)
+			Log("Looking for multimedia for show")
+			try: self.findMultimedia(metadata, [path], 'show')
+			except Exception, e: Log('Error finding show media: %s' % str(e))
 
 		if media.title:
 			title = media.title
@@ -684,81 +695,11 @@ class xbmcnfotv(Agent.TV_Shows):
 					firstEpisodePath = XML.ElementFromURL(pageUrl).xpath('//Part')[0].get('file')
 					seasonPath = os.path.dirname(firstEpisodePath)
 
-					seasonFilename = ""
-					seasonFilenameZero = ""
-					seasonPathFilename = ""
-					if(int(season_num) == 0):
-						seasonFilenameFrodo = 'season-specials-poster.jpg'
-						seasonFilenameEden = 'season-specials.tbn'
-						seasonFilenameZero = 'season00-poster.jpg'
-					else:
-						seasonFilenameFrodo = 'season%(number)02d-poster.jpg' % {"number": int(season_num)}
-						seasonFilenameEden = 'season%(number)02d.tbn' % {"number": int(season_num)}
+					metadata.seasons[season_num].index = int(season_num)
 
-					if not Prefs['localmediaagent']:
-						seasonPosterNames = []
-
-						#Frodo
-						seasonPosterNames.append (os.path.join(path, seasonFilenameFrodo))
-						seasonPosterNames.append (os.path.join(path, seasonFilenameZero))
-						seasonPosterNames.append (os.path.join(seasonPath, seasonFilenameFrodo))
-						seasonPosterNames.append (os.path.join(seasonPath, seasonFilenameZero))
-						#Eden
-						seasonPosterNames.append (os.path.join(path, seasonFilenameEden))
-						seasonPosterNames.append (os.path.join(seasonPath, seasonFilenameEden))
-						#DLNA
-						seasonPosterNames.append (os.path.join(seasonPath, "folder.jpg"))
-						seasonPosterNames.append (os.path.join(seasonPath, "poster.jpg"))
-						#Fallback to Series Poster
-						seasonPosterNames.append (os.path.join(path, "poster.jpg"))
-
-						# check possible season poster file locations
-						seasonPosterFilename = self.checkFilePaths (seasonPosterNames, 'season poster')
-
-						if seasonPosterFilename:
-							seasonData = Core.storage.load(seasonPosterFilename)
-							seasonHash = hashlib.md5(seasonData).hexdigest()
-							metadata.seasons[season_num].posters[seasonHash] = Proxy.Media(seasonData)
-							metadata.seasons[season_num].posters.validate_keys([seasonHash])
-							Log('Found season poster image at ' + seasonPosterFilename)
-
-						# Season Banner
-						seasonBannerFileName = 'season%(number)02d-banner.jpg' % {"number": int(season_num)}
-
-						seasonBannerNames = []
-						seasonBannerNames.append (os.path.join(seasonPath, seasonBannerFileName))
-						seasonBannerNames.append (os.path.join(seasonPath, "banner.jpg"))
-						seasonBannerNames.append (os.path.join(seasonPath, "folder-banner.jpg"))
-						seasonBannerNames.append (os.path.join(path, seasonBannerFileName))
-						seasonBannerNames.append (os.path.join(path, "banner.jpg"))
-						seasonBannerNames.append (os.path.join(path, "folder-banner.jpg"))
-
-						# check possible banner file locations
-						seasonBanner = self.checkFilePaths (seasonBannerNames, 'season banner')
-
-						if seasonBanner:
-							seasonBannerData = Core.storage.load(seasonBanner)
-							seasonBannerHash = hashlib.md5(seasonBannerData).hexdigest()
-							metadata.seasons[season_num].banners[seasonBannerHash] = Proxy.Media(seasonBannerData)
-							metadata.seasons[season_num].banners.validate_keys([seasonBannerHash])
-							Log('Found season banner image at ' + seasonBanner)
-
-						# Season Fanart
-						seasonFanartFileName = 'season%(number)02d-fanart.jpg' % {"number": int(season_num)}
-						seasonFanartNames = []
-						seasonFanartNames.append (os.path.join(seasonPath, seasonFanartFileName))
-						seasonFanartNames.append (os.path.join(path, seasonFanartFileName))
-						seasonFanartNames.append (os.path.join(path, "fanart.jpg"))
-
-						# check possible Fanart file locations
-						seasonFanart = self.checkFilePaths (seasonFanartNames, 'season fanart')
-
-						if seasonFanart:
-							seasonFanartData = Core.storage.load(seasonFanart)
-							seasonFanartHash = hashlib.md5(seasonFanartData).hexdigest()
-							metadata.seasons[season_num].art[seasonFanartHash] = Proxy.Media(seasonFanartData)
-							metadata.seasons[season_num].art.validate_keys([seasonFanartHash])
-							Log('Found season fanart image at ' + seasonFanart)
+					Log('Looking for season media for %s season %s.', metadata.title, season_num)
+					try: self.findMultimedia(metadata.seasons[season_num], [path, seasonPath], 'season')
+					except Exception, e: Log("Error finding season media for season %s: %s" % (season_num, str(e)))
 
 					episodeXML = []
 					epnumber = 0
@@ -1046,30 +987,15 @@ class xbmcnfotv(Agent.TV_Shows):
 											pass
 
 										if not Prefs['localmediaagent']:
-											episodeThumbNames = []
+											multEpisode = (nfoepc > 1) and (not Prefs['multEpisodePlexPatch'] or not multEpTestPlexPatch)
 
-											#Multiepisode nfo thumbs
-											if (nfoepc > 1) and (not Prefs['multEpisodePlexPatch'] or not multEpTestPlexPatch):
-												for name in glob.glob1(os.path.dirname(nfoFile), '*S' + str(season_num.zfill(2)) + 'E' + str(ep_num.zfill(2)) + '*.jpg'):
-													if "-E" in name: continue
-													episodeThumbNames.append (os.path.join(os.path.dirname(nfoFile), name))
+											episodeMetadata = metadata.seasons[season_num].episodes[ep_num]
+											episodeMedia = media.seasons[season_num].episodes[ep_num].items[0]
+											path = os.path.dirname(episodeMedia.parts[0].file)
 
-											#Frodo
-											episodeThumbNames.append (nfoFile.replace('.nfo', '-thumb.jpg'))
-											#Eden
-											episodeThumbNames.append (nfoFile.replace('.nfo', '.tbn'))
-											#DLNA
-											episodeThumbNames.append (nfoFile.replace('.nfo', '.jpg'))
-
-											# check possible episode thumb file locations
-											episodeThumbFilename = self.checkFilePaths (episodeThumbNames, 'episode thumb')
-
-											if episodeThumbFilename:
-												thumbData = Core.storage.load(episodeThumbFilename)
-												thumbHash = hashlib.md5(thumbData).hexdigest()
-												episode.thumbs[thumbHash] = Proxy.Media(thumbData)
-												episode.thumbs.validate_keys([thumbHash])
-												Log('Found episode thumb image at ' + episodeThumbFilename)
+											Log('Looking for episode media for %s season %s.', metadata.title, season_num)
+											try: self.findMultimedia(episodeMetadata, [path], 'episode', episodeMedia.parts, multEpisode)
+											except Exception, e: Log('Error finding media for episode: %s' % str(e))
 
 										Log("---------------------")
 										Log("Episode (S"+season_num.zfill(2)+"E"+ep_num.zfill(2)+") nfo Information")

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -12,6 +12,16 @@
     "default":"false"
   },
   {
+    "id":"assetslocation",
+    "label":"agents artwork location",
+    "type": "enum",
+    "values": [
+      "local",
+      "link",
+    ],
+    "default": "local"
+  },
+  {
     "id":"dayfirst",
     "label":"enable day first in ambiguous dates",
     "type":"bool",


### PR DESCRIPTION
Hello!,

It's me again, I was checking the plugin and I saw that it only loads one image per program, season or episode, however, I have multiple different images for each "season", to which I have added a new function that allows the loading of multiple posters, banners, arts , thumbnails and themes with the same structures presented previously (Frodo, Eden and DLNA).

Example files:
<img src="https://user-images.githubusercontent.com/15143699/64835576-2eeebd80-d5ac-11e9-88ac-d8a6a3495d06.png" height="200" align="left">I should point out that the new function searches the files using the same structure that was already present, here are some search examples:
- folder.jpg | poster.png | poster-1.jpeg | poster-01.jpg | poster01.tbn
- season1-poster.jpg | season01-poster01.png | season-1-art-02.jpeg
- season-01-fanart.jpeg | season-01-banner-02.png
- theme.mp3 | theme01.mp3 | theme2.m4a
- Chernobyl - S01E01 [HD]-thumb.jpg | Chernobyl - S2E3 [HD]-thumb02.png
etc...

Operating example:
![outputplex](https://user-images.githubusercontent.com/15143699/64837643-1f27a700-d5b5-11e9-9980-b463117df6f1.gif)

Without more to say, I hope that this change will helpful.