### PR TITLE
Add support for stacked tv show episodes

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -777,8 +777,10 @@ class xbmcnfotv(Agent.TV_Shows):
 								filepath = path1.split
 								path = os.path.dirname(path1)
 								fileExtension = path1.split(".")[-1].lower()
-
+								
 								nfoFile = path1.replace('.'+fileExtension, '.nfo')
+								# Handling stacked files: part#, cd#, dvd#, pt#, disk#, disc#
+								nfoFile = re.sub(r'[.-]?(part|cd|dvd|pt|disk|disc)\d', '', nfoFile, flags = re.IGNORECASE )
 								self.DLog("Looking for episode NFO file " + nfoFile)
 								if os.path.exists(nfoFile):
 									self.DLog("File exists...")


### PR DESCRIPTION
According to https://support.plex.tv/articles/naming-and-organizing-your-tv-show-files/, plex supports stacked files for tv show episodes. For clarification, I'm talking about single episodes spanning multiple files. There are some shows out there where for example the first episode is split into two files, but only listed as one, sharing the same episode enumeration. This looks like `Burn Notice S01E01 Burn Notice.part1.mkv` and is currently not supported by this agent.

This change adds support for stacked episodes by removing the mentioned filename extensions, allowing the agent to look for the correct file (`Burn Notice S01E01 Burn Notice.nfo`) and therefore filling the missing metadata.

Tested on my machine:
![image](https://user-images.githubusercontent.com/7556827/103245120-76df5280-495f-11eb-817d-d9b247076e21.png)
![image](https://user-images.githubusercontent.com/7556827/103245149-88c0f580-495f-11eb-9d24-cb5954e698b9.png)
