### PR TITLE
UPPERCASE media extensions causing full media files to be read in like nfo files, causing critical failures

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -776,7 +776,7 @@ class xbmcnfotv(Agent.TV_Shows):
 								self.DLog('UPDATE: ' + path1)
 								filepath = path1.split
 								path = os.path.dirname(path1)
-								fileExtension = path1.split(".")[-1].lower()
+								fileExtension = path1.split(".")[-1]
 
 								nfoFile = path1.replace('.'+fileExtension, '.nfo')
 								self.DLog("Looking for episode NFO file " + nfoFile)


### PR DESCRIPTION
This simple fix will avoid major issues trying to read in full video files like they're NFO files.  **Note: I tested this with fake names that happened to be a movie, but the same applies to any TV show episode video files, too**

Working code:
```
>>> path1="/mnt/storage3/temp/movies_tests/Goonies 1986 Test Movie/test movie.mkv"
>>> fileExtension = path1.split(".")[-1]
>>> fileExtension
'mkv'
>>> nfoFile = path1.replace('.'+fileExtension, '.nfo')
>>> nfoFile
'/mnt/storage3/temp/movies_tests/Goonies 1986 Test Movie/test movie.nfo'
>>> path1="/mnt/storage3/temp/movies_tests/Goonies 1986 Test Movie/test movie.MKV"
>>> fileExtension = path1.split(".")[-1]
>>> fileExtension
'MKV'
>>> nfoFile = path1.replace('.'+fileExtension, '.nfo')
>>> nfoFile
'/mnt/storage3/temp/movies_tests/Goonies 1986 Test Movie/test movie.nfo'
```

Old code, not working, as it attempts to read in the MKV file instead of an nfo file:
```
>>> path1="/mnt/storage3/temp/movies_tests/Goonies 1986 Test Movie/test movie.MKV"
>>> fileExtension = path1.split(".")[-1].lower()
>>> fileExtension
'mkv'
>>> nfoFile = path1.replace('.'+fileExtension, '.nfo')
>>> nfoFile
'/mnt/storage3/temp/movies_tests/Goonies 1986 Test Movie/test movie.MKV'
```